### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,48 @@
+# ⚖️ Code of Conduct: SpectraGraph
+
+## 1. Our Pledge
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in the **SpectraGraph** project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+---
+
+## 2. Ethical OSINT Standards
+As an Open-Source Intelligence (OSINT) tool, SpectraGraph carries a significant responsibility. All contributors must adhere to the following project-specific ethical principles:
+
+* **Privacy First:** Contributions must not encourage or facilitate illegal doxxing or the exposure of non-public personal information (PII).
+* **Investigative Neutrality:** Tools and transforms should be built for objective data analysis. We do not support features designed for targeted harassment or mass surveillance.
+* **Transparency:** All data enrichment logic (Transforms) must be transparent, repeatable, and defensible. No "black box" logic.
+* **Legal Compliance:** Contributions must respect the Terms of Service (ToS) of the external APIs used (e.g., Shodan, VirusTotal, GitHub).
+
+---
+
+## 3. Our Standards
+**Examples of behavior that contributes to a positive environment include:**
+* Using welcoming and inclusive language.
+* Being respectful of differing viewpoints and experiences.
+* Gracefully accepting constructive criticism.
+* Focusing on what is best for the community and the project's integrity.
+* Showing empathy towards other community members.
+
+**Examples of unacceptable behavior include:**
+* The use of sexualized language or imagery and unwelcome sexual attention or advances.
+* Trolling, insulting/derogatory comments, and personal or political attacks.
+* Public or private harassment.
+* Publishing others' private information (doxxing) without explicit permission.
+* Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+---
+
+## 4. Scope
+This Code of Conduct applies both within project spaces (GitHub, Discord, Slack) and in public spaces when an individual is representing the project or its community.
+
+---
+
+## 5. Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project admin, **Nitya**, through official SWoC communication channels or GitHub. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+---
+
+## 6. Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4.


### PR DESCRIPTION
## 🔗 Linked Issue
Closes #33

## 🛠 Type of Change
- [x] **Documentation** - Added CODE_OF_CONDUCT.md.

## 📝 Summary
This PR introduces the official Code of Conduct to ensure a safe, inclusive, and ethical environment for all **SWoC '26** contributors. 

**Highlights of this CoC:**
- **Ethical OSINT Clauses:** Explicitly prohibits the development of tools for doxxing or mass surveillance.
- **TOS Compliance:** Reminds contributors to respect external API provider terms (Shodan, VT, etc.).
- **Enforcement:** Clear pathways for reporting harassment or ethical violations to project maintainers.
- **Inclusive Language:** Adopted from the Contributor Covenant 1.4 standards.

## 🧪 Testing Evidence
- Verified file rendering in GitHub Markdown preview.
- Ensured all links to the Contributor Covenant are functional.
- Verified that the file is in the root directory for GitHub "Community Profile" recognition.

## 🛡 Ethical Review
- [x] I confirm this document aligns with SpectraGraph’s mission of transparent and defensible intelligence gathering.